### PR TITLE
[FIX] stock: _update_available_quantity avoid serialization failure

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -223,7 +223,7 @@ class StockQuant(models.Model):
                     })
                     break
             except OperationalError as e:
-                if e.pgcode == '55P03':  # could not obtain the lock
+                if e.pgcode == '55P03' or e.pgcode == '40001':  # could not obtain the lock or serialization failure
                     continue
                 else:
                     raise

--- a/doc/cla/corporate/dgtera.md
+++ b/doc/cla/corporate/dgtera.md
@@ -13,3 +13,4 @@ Eslam Youssef iay@dgtera.com https://github.com/IAY-DGTERA
 List of contributors:
 
 Eslam Youssef iay@dgtera.com https://github.com/IAY-DGTERA
+

--- a/doc/cla/corporate/dgtera.md
+++ b/doc/cla/corporate/dgtera.md
@@ -1,0 +1,15 @@
+Saudi Arabia, 21/11/2020
+
+Dgtera agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Eslam Youssef iay@dgtera.com https://github.com/IAY-DGTERA
+
+List of contributors:
+
+Eslam Youssef iay@dgtera.com https://github.com/IAY-DGTERA


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

serialization failures would appear in the case of multi cron jobs affecting the stock at the same time

Current behavior before PR:

serialization failures would appear in the case of multi cron jobs trying to acquire the lock in
`self._cr.execute("SELECT 1 FROM stock_quant WHERE id = %s FOR UPDATE NOWAIT", [quant.id], log_exceptions=False)`
as it could have obtained the lock, as the lock is currently available. But it had been locked at some previous point which overlaps with the current transaction's snapshot. So obtaining the lock is possible, but would create a serialization problem if it were to acquire it. Reporting that as a serialization failure seems like the correct outcome.

Desired behavior after PR is merged:

if the serialization failure happens we skip it and go to the next quant or create one if needed

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
